### PR TITLE
Fix show/clip for un-encrypted tokens

### DIFF
--- a/lib/common
+++ b/lib/common
@@ -83,7 +83,7 @@ plaintext_token_from_file()
 get_token()
 {
   get_token_file
-  if [ -f "$TOKEN_FILE" ]; then
+  if [ -f "$TOKEN_FILE" ] && [ ${TOKEN_FILE: -4} == ".enc" ]; then
     TOKEN=$( decrypt_token_from_file $TOKEN_FILE )
   else
     TOKEN=$( plaintext_token_from_file $TOKEN_FILE )


### PR DESCRIPTION
After `get_token_file` is called, the former functionality would check in the if statement to verify that it got a valid file back, but didn't check if the returned file was encrypted. 

The effect was that an unencrypted token file (plain-text, no password) would still get prompted for `OTP Password:` and would subsequently fail decryption if you left it empty.

This add checks that the file returned from `get_token_file` has a `.enc` extension before trying to decrypt, else falls back to the plain-text output.