### PR TITLE
On macos, use the native system path to stat command

### DIFF
--- a/lib/common
+++ b/lib/common
@@ -39,7 +39,7 @@ set_tokenfiles_dir()
 check_permissions()
 {
   if [ $OS = "Darwin" ]; then
-    PERMISSIONS=$( stat -L -f "%A" $1 )
+    PERMISSIONS=$( /usr/bin/stat -L -f "%A" $1 )
   elif [ $OS = "Linux" ]; then
     PERMISSIONS=$( stat -L -c "%a" $1 )
   else


### PR DESCRIPTION
This fixes https://github.com/rfocosi/otp-cli/issues/6

On macos systems that resolve `stat` to the GNU version instead of the native BSD version, it blows up the `lib/common` `check_permissions()` function.

```sh
$ otp-cli help
stat: cannot read file system information for '%A': No such file or directory
~/.homesick/repos/otp-cli/lib/common: line 50: [: too many arguments
```

This PR fixes this by using the absolute path to the native BSD version of `stat`.

```sh
$ which stat
/usr/local/opt/coreutils/libexec/gnubin/stat

$ stat -L -f "%A" ~/otp-cli/tokens/example.enc
stat: cannot read file system information for '%A': No such file or directory
  File: "~/otp-cli/tokens/example.enc"
    ID: 100000400000019 Namelen: ?       Type: apfs
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 122086923  Free: 84514192   Available: 81211171
Inodes: Total: 4883476920 Free: 4882127831

# if I use the system's built-in, BSD version of stat, then all is well:
$ /usr/bin/stat -L -f "%A" ~/otp-cli/tokens/example.enc
400
```