### PR TITLE
Checking stat version

### DIFF
--- a/lib/common
+++ b/lib/common
@@ -38,13 +38,10 @@ set_tokenfiles_dir()
 
 check_permissions()
 {
-  if [ $OS = "Darwin" ]; then
-    PERMISSIONS=$( stat -L -f "%A" $1 )
-  elif [ $OS = "Linux" ]; then
+  if [ $( stat --version | head -n 1 | grep -c GNU ) = "1" ]; then
     PERMISSIONS=$( stat -L -c "%a" $1 )
   else
-    # Do not check permissions
-    PERMISSIONS=$2
+    PERMISSIONS=$( stat -L -f "%A" $1 )
   fi
 
   if [ $PERMISSIONS != $2 ]; then


### PR DESCRIPTION
Fix a issue when a system has two stat versions: GNU and BSD
It uses the correct version