### PR TITLE
Adds parameter for only printing the OTP and nothing else

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Usage: otp-cli show [-h] [-1] [-c] [-s] <Token Name>
 
  -1 : Get one password and exit.
  -c : Copy to clipboard.
+ -z : Only print OTP.
  -s : Silent. Do not output anything to console.
 ```
 

--- a/lib/show
+++ b/lib/show
@@ -10,6 +10,7 @@ validate_modifiers()
   do
     [ "$1" = "-c" ] && TO_CLIPBOARD=true
     [ "$1" = "-1" ] && ONE_TIME=true
+    [ "$1" = "-z" ] && ONLY_OTP=true
     [ "$1" = "-s" ] && OUTPUT="/dev/null"
     [ $1 != -* ] && TOKEN_NAME="$1"
     shift
@@ -25,6 +26,7 @@ show_usage()
   echo " -h : This help"
   echo " -1 : Get one password and exit."
   echo " -c : Copy to clipboard."
+  echo " -z : Only print OTP."
   echo " -s : Silent. Do not output anything to console."
   exit 1
 }
@@ -36,7 +38,7 @@ read_token_name
 
 get_token
 
-echo > $( echo "$OUTPUT" )
+[ -z "$ONE_TIME" ] && echo > $( echo "$OUTPUT" )
 
 [ $ONE_TIME ] && [ $WAIT_FOR_NEXT -gt 0 ] && WAIT=true
 
@@ -52,8 +54,10 @@ while true; do
   process_otp
 
   [ $WAIT ] && [ $WAIT_FOR_NEXT -ge $REMAINING ] && OTP="(Waiting for next token ...)"
+  
 
-  display_message=`printf "[%.2d] $OTP" $REMAINING`
+  [ $ONLY_OTP ] && display_message="$OTP" || display_message=`printf "[%.2d] $OTP" $REMAINING`
+
 
   printf "\r" > $( echo "$OUTPUT" )
   [ $display_message_size ] && for i in {1..$display_message_size}; do printf " " > $( echo "$OUTPUT" ); done


### PR DESCRIPTION
# Feature: Add `-z` option to `show` command and improve output formatting

This PR introduces a new feature to the `show` command and addresses some minor output formatting issues, enhancing the user experience and scriptability of `otp-cli`.

### New Feature: `-z` (Show OTP Only) Option

*   **`otp-cli show -z <token_name>`**

A new `-z` option has been added to the `show` command. When this flag is used, `otp-cli` will print only the OTP, without the preceding countdown timer.

This aids the script when used in scripting situations, such as piping an otp into another application with
`otp-cli show -z -1 <token_name>`


### Minor tweak to how -1 is printed
    *   Fixed an issue where an unnecessary leading blank line was printed when using the `show -1` option.
